### PR TITLE
bumping the log version to 0.4.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ repository = "https://github.com/luser/read-process-memory"
 
 [dependencies]
 libc = "0.2.15"
-log = "0.3.6"
+log = "0.4.6"
 
 [target.'cfg(target_os="macos")'.dependencies]
 mach = "0.0.5"


### PR DESCRIPTION
I am currently trying to package py-spy for Fedora but as Fedora only has log 0.4 in its repositories and as py-spy depends on this package, this dependency must be updated so I can continue.