### PR TITLE
Fallback to direct read from memory is now in case of any error, not only for ENOSYS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,15 +108,9 @@ mod platform {
             };
             let result = unsafe { process_vm_readv(self.0, &local_iov, 1, &remote_iov, 1, 0) };
             if result == -1 {
-                if let Some(libc::ENOSYS) = io::Error::last_os_error().raw_os_error() {
-                    // fallback to reading /proc/$pid/mem if kernel does not
-                    // implement process_vm_readv()
-                    let mut procmem = fs::File::open(format!("/proc/{}/mem", self.0))?;
-                    procmem.seek(io::SeekFrom::Start(addr as u64))?;
-                    return procmem.read_exact(buf);
-                } else {
-                    Err(io::Error::last_os_error())
-                }
+                let mut procmem = fs::File::open(format!("/proc/{}/mem", self.0))?;
+                procmem.seek(io::SeekFrom::Start(addr as u64))?;
+                return procmem.read_exact(buf);
             } else {
                 Ok(())
             }


### PR DESCRIPTION
We, at [pyroscope.io](https://github.com/pyroscope-io/pyroscope/), are using pyspy & rbspy which both are using this library underneath. For cases when `process_vm_readv()` is forbidden ( due to seccomp settings in Docker, or by disabling SYS_PTRACE capabilities for user ) the fallback to direct memory read is not working. Imo, it should be possible to do a fallback to direct memory read in case of any case when `process_vm_readv()` is failing.

Some of our users, who are using Docker, Podman or Heroku, don't have possibilities to change permissions on their platform to be able to use `process_vm_readv()`. For those cases, the only way is to read memory directly from `/dev/<pid>/mem`.

@benfred Please take a look at this change. I am open for discussion.